### PR TITLE
v5.1.2.1 - update gui digest to pull new gui with log4j 2.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IBM Spectrum Scale container native
 
-IBM Spectrum Scale in containers allows the deployment of the cluster file system in a Red Hat® OpenShift® cluster. Using a remote mount attached file system, the IBM Spectrum Scale solution provides a persistent data store to be accessed by the applications via the [IBM Spectrum Scale Container Storage Interface (CSI) driver](https://www.ibm.com/support/knowledgecenter/STXKQY_CSI_SHR/com.ibm.spectrum.scale.csi.v2r10.doc/bl1csi_kc_landing.html) using Persistent Volumes (PVs).
+IBM Spectrum Scale in containers allows the deployment of the cluster file system in a Red Hat® OpenShift® cluster. Using a remote mount attached file system, the IBM Spectrum Scale solution provides a persistent data store to be accessed by the applications via the [IBM Spectrum Scale Container Storage Interface (CSI) driver](https://www.ibm.com/docs/en/spectrum-scale-csi) using Persistent Volumes (PVs).
 
 This project contains a golang-based operator to run and manage the deployment of an IBM Spectrum Scale container native cluster. Entitlement is required to access Spectrum Scale images required to created a container native Spectrum Scale cluster.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IBM Spectrum Scale container native
 
-IBM Spectrum Scale in containers allows the deployment of the cluster file system in a Red Hat® OpenShift® cluster. Using a remote mount attached file system, the IBM Spectrum Scale solution provides a persistent data store to be accessed by the applications via the [IBM Spectrum Scale Container Storage Interface (CSI) driver](https://www.ibm.com/docs/en/spectrum-scale-csi) using Persistent Volumes (PVs).
+IBM Spectrum Scale in containers allows the deployment of the cluster file system in a Red Hat® OpenShift® cluster. Using a remote mount attached file system, the IBM Spectrum Scale solution provides a persistent data store to be accessed by the applications via the [IBM Spectrum Scale Container Storage Interface (CSI) driver](https://www.ibm.com/support/knowledgecenter/STXKQY_CSI_SHR/com.ibm.spectrum.scale.csi.v2r10.doc/bl1csi_kc_landing.html) using Persistent Volumes (PVs).
 
 This project contains a golang-based operator to run and manage the deployment of an IBM Spectrum Scale container native cluster. Entitlement is required to access Spectrum Scale images required to created a container native Spectrum Scale cluster.
 

--- a/config/scale/operator/manager/controller_manager_config.yaml
+++ b/config/scale/operator/manager/controller_manager_config.yaml
@@ -15,7 +15,7 @@ images:
   coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:6d477c4115ab84777f199e0dd2cf4ba40bd3825d903498667de414b890b66bff
   coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:27d65e1edeaa656ea091f410d673ca8af2701375d254b181a726c63c96141e5b
   coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:1d1f2e1d2c035d1c58aac20961071c8cd011852acfaf977928f0de2ee536279c
-  gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:a57b1b9f27f015d2f33fe981e88996df0a335381c8243a6beb129557b2049ac9
+  gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:d7d5cd92fda7cbc462c2d4684539ba51e952196d645fd9f0e882b7253f5e14b9
   postgres: cp.icr.io/cp/spectrum/scale/postgres@sha256:a2da8071b8eba341c08577b13b41527eab3968bf1c8d28123b5b07a493a26862
   logs: cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:d9b92ea78e76300968f5c9a4a04c2cf220a0bbfac667f77e5e7287692163d898
   pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:9f21c31541a1e85c7f9eae2a695b19c57b85a7731286a277f9cd5184e8c87323

--- a/generated/installer/ibm-spectrum-scale-excluding-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-excluding-operator.yaml
@@ -2898,7 +2898,7 @@ data:
       coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:6d477c4115ab84777f199e0dd2cf4ba40bd3825d903498667de414b890b66bff
       coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:27d65e1edeaa656ea091f410d673ca8af2701375d254b181a726c63c96141e5b
       coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:1d1f2e1d2c035d1c58aac20961071c8cd011852acfaf977928f0de2ee536279c
-      gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:a57b1b9f27f015d2f33fe981e88996df0a335381c8243a6beb129557b2049ac9
+      gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:d7d5cd92fda7cbc462c2d4684539ba51e952196d645fd9f0e882b7253f5e14b9
       postgres: cp.icr.io/cp/spectrum/scale/postgres@sha256:a2da8071b8eba341c08577b13b41527eab3968bf1c8d28123b5b07a493a26862
       logs: cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:d9b92ea78e76300968f5c9a4a04c2cf220a0bbfac667f77e5e7287692163d898
       pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:9f21c31541a1e85c7f9eae2a695b19c57b85a7731286a277f9cd5184e8c87323

--- a/generated/installer/ibm-spectrum-scale-operator.yaml
+++ b/generated/installer/ibm-spectrum-scale-operator.yaml
@@ -2898,7 +2898,7 @@ data:
       coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:6d477c4115ab84777f199e0dd2cf4ba40bd3825d903498667de414b890b66bff
       coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:27d65e1edeaa656ea091f410d673ca8af2701375d254b181a726c63c96141e5b
       coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:1d1f2e1d2c035d1c58aac20961071c8cd011852acfaf977928f0de2ee536279c
-      gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:a57b1b9f27f015d2f33fe981e88996df0a335381c8243a6beb129557b2049ac9
+      gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:d7d5cd92fda7cbc462c2d4684539ba51e952196d645fd9f0e882b7253f5e14b9
       postgres: cp.icr.io/cp/spectrum/scale/postgres@sha256:a2da8071b8eba341c08577b13b41527eab3968bf1c8d28123b5b07a493a26862
       logs: cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:d9b92ea78e76300968f5c9a4a04c2cf220a0bbfac667f77e5e7287692163d898
       pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:9f21c31541a1e85c7f9eae2a695b19c57b85a7731286a277f9cd5184e8c87323


### PR DESCRIPTION
new gui builds to address cve-2021-44228 and cve-2021-45046