### PR TITLE
Add OCP 4.10 support for CNSA 5.1.3.0

### DIFF
--- a/config/csi/kustomization.yaml
+++ b/config/csi/kustomization.yaml
@@ -2,7 +2,7 @@
 namespace: ibm-spectrum-scale-csi
 
 resources:
-- github.com/IBM/ibm-spectrum-scale-csi.git?ref=dev
+- github.com/IBM/ibm-spectrum-scale-csi.git?ref=v2.5.0
 - namespace.yaml
 
 patches:

--- a/config/scale/machineconfig/ocp4.10/base/00-worker-ibm-spectrum-scale-kernel-devel.yaml
+++ b/config/scale/machineconfig/ocp4.10/base/00-worker-ibm-spectrum-scale-kernel-devel.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "worker"
+  name: 00-worker-ibm-spectrum-scale-kernel-devel
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  extensions:
+     - kernel-devel

--- a/config/scale/machineconfig/ocp4.10/base/01-worker-ibm-spectrum-scale-increase-pid-limit.yaml
+++ b/config/scale/machineconfig/ocp4.10/base/01-worker-ibm-spectrum-scale-increase-pid-limit.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: 01-worker-ibm-spectrum-scale-increase-pid-limit
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ''
+  containerRuntimeConfig:
+    pidsLimit: 4096

--- a/config/scale/machineconfig/ocp4.10/base/kustomization.yaml
+++ b/config/scale/machineconfig/ocp4.10/base/kustomization.yaml
@@ -1,0 +1,7 @@
+# resources contains the requisite Machine Configurations necessary to run IBM Spectrum
+# Scale Container Native storage access:
+#   - Make the kernel packages available; kernel-devel and kernel-headers
+#   - Increase the PID limit
+resources:
+  - 00-worker-ibm-spectrum-scale-kernel-devel.yaml
+  - 01-worker-ibm-spectrum-scale-increase-pid-limit.yaml

--- a/config/scale/machineconfig/ocp4.10/ppc64le/kustomization.yaml
+++ b/config/scale/machineconfig/ocp4.10/ppc64le/kustomization.yaml
@@ -1,0 +1,6 @@
+# resources contains the requisite Machine Configurations necessary to run IBM Spectrum
+# Scale Container Native storage access:
+#   - Make the kernel packages available; kernel-devel and kernel-headers
+#   - Increase the PID limit
+bases:
+  - ../base

--- a/config/scale/machineconfig/ocp4.10/s390x/02-worker-ibm-spectrum-scale-s390x-vmalloc.yaml
+++ b/config/scale/machineconfig/ocp4.10/s390x/02-worker-ibm-spectrum-scale-s390x-vmalloc.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 02-worker-ibm-spectrum-scale-s390x-vmalloc 
+spec:
+  kernelArguments:
+    - 'vmalloc=4096G'

--- a/config/scale/machineconfig/ocp4.10/s390x/kustomization.yaml
+++ b/config/scale/machineconfig/ocp4.10/s390x/kustomization.yaml
@@ -1,0 +1,11 @@
+# For s390x, the following Machine Configuration will increase the VM allocation
+# to a value that necesitates running IBM Spectrum Scale
+resources:
+  - 02-worker-ibm-spectrum-scale-s390x-vmalloc.yaml
+
+# base will apply the requisite Machine Configurations necessary to run IBM Spectrum
+# Scale Container Native storage access:
+#   - Make the kernel packages available; kernel-devel and kernel-headers
+#   - Increase the PID limit
+bases:
+  - ../base

--- a/config/scale/machineconfig/ocp4.10/x86_64/kustomization.yaml
+++ b/config/scale/machineconfig/ocp4.10/x86_64/kustomization.yaml
@@ -1,0 +1,6 @@
+# resources contains the requisite Machine Configurations necessary to run IBM Spectrum
+# Scale Container Native storage access:
+#   - Make the kernel packages available; kernel-devel and kernel-headers
+#   - Increase the PID limit
+bases:
+  - ../base

--- a/generated/mco/ocp4.10/mco_ppc64le.yaml
+++ b/generated/mco/ocp4.10/mco_ppc64le.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: 01-worker-ibm-spectrum-scale-increase-pid-limit
+spec:
+  containerRuntimeConfig:
+    pidsLimit: 4096
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 00-worker-ibm-spectrum-scale-kernel-devel
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  extensions:
+  - kernel-devel

--- a/generated/mco/ocp4.10/mco_s390x.yaml
+++ b/generated/mco/ocp4.10/mco_s390x.yaml
@@ -1,0 +1,33 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: 01-worker-ibm-spectrum-scale-increase-pid-limit
+spec:
+  containerRuntimeConfig:
+    pidsLimit: 4096
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 00-worker-ibm-spectrum-scale-kernel-devel
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  extensions:
+  - kernel-devel
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 02-worker-ibm-spectrum-scale-s390x-vmalloc
+spec:
+  kernelArguments:
+  - vmalloc=4096G

--- a/generated/mco/ocp4.10/mco_x86_64.yaml
+++ b/generated/mco/ocp4.10/mco_x86_64.yaml
@@ -1,0 +1,23 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+  name: 01-worker-ibm-spectrum-scale-increase-pid-limit
+spec:
+  containerRuntimeConfig:
+    pidsLimit: 4096
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 00-worker-ibm-spectrum-scale-kernel-devel
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  extensions:
+  - kernel-devel


### PR DESCRIPTION
- Add OCP 4.10 Machine Configuration files - these remain the same as past OCP releases