### PR TITLE
IBM Spectrum Scale Container Native v5.2.1.1.3 11/14/2024

### DIFF
--- a/config/cluster/base/service_account_core.yaml
+++ b/config/cluster/base/service_account_core.yaml
@@ -5,5 +5,4 @@ metadata:
   name: core
 imagePullSecrets:
   # TODO: ibm-spectrum-scale- will get double added if a user creates a secrets directory. We need to handle this better probably
-  - name: ibm-spectrum-scale-registrykey
   - name: ibm-entitlement-key

--- a/config/cluster/base/service_account_default.yaml
+++ b/config/cluster/base/service_account_default.yaml
@@ -5,6 +5,5 @@ metadata:
   name: default
 imagePullSecrets:
   # TODO: ibm-spectrum-scale- will get double added if a user creates a secrets directory. We need to handle this better probably
-  - name: ibm-spectrum-scale-registrykey
   - name: ibm-entitlement-key
 automountServiceAccountToken: false

--- a/config/cluster/base/service_account_gui.yaml
+++ b/config/cluster/base/service_account_gui.yaml
@@ -5,6 +5,5 @@ metadata:
   name: gui
 imagePullSecrets:
   # TODO: ibm-spectrum-scale- will get double added if a user creates a secrets directory. We need to handle this better probably
-  - name: ibm-spectrum-scale-registrykey
   - name: ibm-entitlement-key
 automountServiceAccountToken: false

--- a/config/cluster/base/service_account_pmcollector.yaml
+++ b/config/cluster/base/service_account_pmcollector.yaml
@@ -5,6 +5,5 @@ metadata:
   name: pmcollector
 imagePullSecrets:
   # TODO: ibm-spectrum-scale- will get double added if a user creates a secrets directory. We need to handle this better probably
-  - name: ibm-spectrum-scale-registrykey
   - name: ibm-entitlement-key
 automountServiceAccountToken: false

--- a/config/cluster/base/service_account_regionaldr.yaml
+++ b/config/cluster/base/service_account_regionaldr.yaml
@@ -5,5 +5,4 @@ metadata:
   name: regional-dr
 imagePullSecrets:
   # TODO: ibm-spectrum-scale- will get double added if a user creates a secrets directory. We need to handle this better probably
-  - name: ibm-spectrum-scale-registrykey
   - name: ibm-entitlement-key

--- a/config/coredns/rbac/service_account.yaml
+++ b/config/coredns/rbac/service_account.yaml
@@ -6,5 +6,4 @@ metadata:
   namespace: system
 imagePullSecrets:
   # TODO: ibm-spectrum-scale- will get double added if a user creates a secrets directory. We need to handle this better probably
-  - name: ibm-spectrum-scale-registrykey
   - name: ibm-entitlement-key

--- a/config/operator/components/rbac/deploy/manager_service_account.yaml
+++ b/config/operator/components/rbac/deploy/manager_service_account.yaml
@@ -6,5 +6,4 @@ metadata:
   namespace: system
 imagePullSecrets:
 # TODO: ibm-spectrum-scale- will get double added if a user creates a secrets directory. We need to handle this better probably
-  - name: ibm-spectrum-scale-registrykey
   - name: ibm-entitlement-key

--- a/config/operator/overlays/manager/controller_manager_config.yaml
+++ b/config/operator/overlays/manager/controller_manager_config.yaml
@@ -1,18 +1,18 @@
 apiVersion: scale.spectrum.ibm.com/v1alpha1
 kind: ClusterManagerConfig
 images:
-  coreECE: cp.icr.io/cp/spectrum/scale/erasure-code/ibm-spectrum-scale-daemon@sha256:4e999404fa87c8ae4084fe3f289017264abeda5b37fcca3df9b4c56b634f8d9e
-  coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:2e32514cec7dbc2f69606afebfaba423faff6ac02202eade9b60046bd00973c4
-  coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:3a5ae3d3d6d04c21d529cb8e725fae705fdba4ac4a2ca33e5c66a39c6cefa0a1
-  coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:93ba38c8387dc8b7492c736f9c4bd5082aba87b679ecace18812eb2d88836e5e
+  coreECE: cp.icr.io/cp/spectrum/scale/erasure-code/ibm-spectrum-scale-daemon@sha256:dd7d1b3b4e691008c007981df55896d4f2a79f3e189e83de463f81e855efd4e3
+  coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:3ed9321e4f3da7bbf75f99e8b4fd7b57139f793509b47a33cfeb51c66f20518f
+  coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:54871bd8d09fd62d62dee7ffcae655297a0d73641849e962a4f5adac618e5b5e
+  coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:ac0a1702d79c12b49e6cbcdabbc293d1cfe7c4dce60087f92d12e1c4d827f1cc
   gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:3692748b236758ada23f80a67fba5fbbf165acc995ce2da523de51a59a300675
   postgres: cp.icr.io/cp/spectrum/scale/postgres@sha256:bbd7346fab25b7e0b25f214829d6ebfb78ef0465059492e46dee740ce8fcd844
   logs: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-logs@sha256:22c973b4ac5f6ff00a2cadc474c695513ad8246614ab0d145ae5612a6fd769f4
-  pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:5eeb3546a49fce400eb855be65ba00b2ae1eacc231c98e617e7185f080fc7b9a
+  pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:de8f2f45b5cf33a018e8ffdda25d53f752d0365278587565306eb194696368e5
   sysmon: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:7ebe93f44ad6d08a6db9919b775819d2fd2780f3f426ed745736b9247da03ce9
   grafanaBridge: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:65a14666cc3dc2ad7516b715f175ddfc18a6f2b5b6c1a3966560b03d6fd02f99
   coreDNS: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-coredns@sha256:88cbfe40fd302a6467cb7e852b298f6c8d8659782ab313706d491d3ddf172a6e
   mustGather: icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:fd1c27c6cf5d34782c5fe718486fab38ba9c8227b4d81961b5e39b692fbd6aa7
-  ganesha: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-ganesha@sha256:6aebc97479025285f790aea051d95af9d04e1769f40c604fa7f86cfdfe1bcfb5
+  ganesha: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-ganesha@sha256:99c4c981a6ca7366af247c16890a23903a659195aefa9bbe9302247602260ce7
   stunnel: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-stunnel@sha256:bd1f4607c8b02063dde8aff7caa9eee732ffdf2c5d535d0b5eff6c9616359cdd
-  pmsensors: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:3ec814f4260df9ac627a36e5682d7c73502b27b73854ec2edd3807f26b5b0d4f
+  pmsensors: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:7a9e836c4385ff50c0bae957e1936d2a1a350ffc465bc278371f89f22d9e76b5

--- a/config/operator/overlays/manager/kustomization.yaml
+++ b/config/operator/overlays/manager/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
   name: manager-config
 
 images:
-- digest: sha256:b6fb2a894bd05ce05580466f2307d4c871dc49da14453c96f081ab3b13c76bc8
+- digest: sha256:e3fa797d4cc30a35050c78203fc38ed73637c1b0a61cbd4c18c29c69ba5fa649
   name: controller
   newName: icr.io/cpopen/ibm-spectrum-scale-operator
 

--- a/generated/scale/README.md
+++ b/generated/scale/README.md
@@ -7,7 +7,7 @@ The images that are listed in the following table are the container images that 
 
 | Pod | Container | Repository | Image |
 |-----|-----------|------------|---------------------|
-| ibm-spectrum-scale-controller-manager-XXXXXXXXX-XXXXX | manager | icr.io/cpopen | ibm-spectrum-scale-operator@sha256:b6fb2a894bd05ce05580466f2307d4c871dc49da14453c96f081ab3b13c76bc8 |
+| ibm-spectrum-scale-controller-manager-XXXXXXXXX-XXXXX | manager | icr.io/cpopen | ibm-spectrum-scale-operator@sha256:e3fa797d4cc30a35050c78203fc38ed73637c1b0a61cbd4c18c29c69ba5fa649 |
 | ibm-spectrum-scale-csi-operator | operator | icr.io/cpopen  | ibm-spectrum-scale-csi-operator@sha256:99ba046ccc9f90777366ebc0dbee55309460d312f68da0f371c176513b5e9592 |
 | must-gather-XXXXX | must-gather | icr.io/cpopen | ibm-spectrum-scale-must-gather@sha256:fd1c27c6cf5d34782c5fe718486fab38ba9c8227b4d81961b5e39b692fbd6aa7 |
 {: caption="Images (non-entitled)" caption-side="bottom"}
@@ -18,16 +18,16 @@ The images that are listed in the following table are the container images that 
 
 | Pod | Container | Repository | Image |
 |-----|-----------|------------|---------------------|
-| workerX/masterX* | mmbuildgpl | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-core-init@sha256:93ba38c8387dc8b7492c736f9c4bd5082aba87b679ecace18812eb2d88836e5e |
-| workerX/masterX* | config | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-core-init@sha256:93ba38c8387dc8b7492c736f9c4bd5082aba87b679ecace18812eb2d88836e5e |
-| workerX/masterX* | gpfs (if using Data Access Edition) | cp.icr.io/cp/spectrum/scale/data-access | ibm-spectrum-scale-daemon@sha256:3a5ae3d3d6d04c21d529cb8e725fae705fdba4ac4a2ca33e5c66a39c6cefa0a1 |
-| workerX/masterX* | gpfs (if using Data Management Edition) | cp.icr.io/cp/spectrum/scale/data-management | ibm-spectrum-scale-daemon@sha256:2e32514cec7dbc2f69606afebfaba423faff6ac02202eade9b60046bd00973c4 |
+| workerX/masterX* | mmbuildgpl | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-core-init@sha256:ac0a1702d79c12b49e6cbcdabbc293d1cfe7c4dce60087f92d12e1c4d827f1cc |
+| workerX/masterX* | config | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-core-init@sha256:ac0a1702d79c12b49e6cbcdabbc293d1cfe7c4dce60087f92d12e1c4d827f1cc |
+| workerX/masterX* | gpfs (if using Data Access Edition) | cp.icr.io/cp/spectrum/scale/data-access | ibm-spectrum-scale-daemon@sha256:54871bd8d09fd62d62dee7ffcae655297a0d73641849e962a4f5adac618e5b5e |
+| workerX/masterX* | gpfs (if using Data Management Edition) | cp.icr.io/cp/spectrum/scale/data-management | ibm-spectrum-scale-daemon@sha256:3ed9321e4f3da7bbf75f99e8b4fd7b57139f793509b47a33cfeb51c66f20518f |
 | workerX/masterX* | logs | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-logs@sha256:22c973b4ac5f6ff00a2cadc474c695513ad8246614ab0d145ae5612a6fd769f4  |
 | ibm-spectrum-scale-gui-X | liberty | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-gui@sha256:3692748b236758ada23f80a67fba5fbbf165acc995ce2da523de51a59a300675 |
 | ibm-spectrum-scale-gui-X | sysmon | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-monitor@sha256:7ebe93f44ad6d08a6db9919b775819d2fd2780f3f426ed745736b9247da03ce9 |
 | ibm-spectrum-scale-gui-X | postgres | cp.icr.io/cp/spectrum/scale | postgres@sha256:bbd7346fab25b7e0b25f214829d6ebfb78ef0465059492e46dee740ce8fcd844 |
 | ibm-spectrum-scale-gui-X | logs | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-logs@sha256:22c973b4ac5f6ff00a2cadc474c695513ad8246614ab0d145ae5612a6fd769f4 |
-| ibm-spectrum-scale-pmcollector-X | pmcollector | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-pmcollector@sha256:5eeb3546a49fce400eb855be65ba00b2ae1eacc231c98e617e7185f080fc7b9a |
+| ibm-spectrum-scale-pmcollector-X | pmcollector | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-pmcollector@sha256:de8f2f45b5cf33a018e8ffdda25d53f752d0365278587565306eb194696368e5 |
 | ibm-spectrum-scale-pmcollector-X | sysmon | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-monitor@sha256:7ebe93f44ad6d08a6db9919b775819d2fd2780f3f426ed745736b9247da03ce9 |
 | ibm-spectrum-scale-csi-snapshotter | csi-snapshotter | cp.icr.io/cp/spectrum/scale/csi | csi-snapshotter@sha256:2e04046334baf9be425bb0fa1d04c2d1720d770825eedbdbcdb10d430da4ad8c  |
 | ibm-spectrum-scale-csi-attacher | ibm-spectrum-scale-csi-attacher | cp.icr.io/cp/spectrum/scale/csi | csi-attacher@sha256:b4d611100ece2f9bc980d1cb19c2285b8868da261e3b1ee8f45448ab5512ab94 |
@@ -52,17 +52,17 @@ When setting up your environment to be air-gapped, use `skopeo` to copy the foll
 
 ```bash
 # IBM Storage Scale container native images
-icr.io/cpopen/ibm-spectrum-scale-operator@sha256:b6fb2a894bd05ce05580466f2307d4c871dc49da14453c96f081ab3b13c76bc8
-cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:3a5ae3d3d6d04c21d529cb8e725fae705fdba4ac4a2ca33e5c66a39c6cefa0a1
-cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:2e32514cec7dbc2f69606afebfaba423faff6ac02202eade9b60046bd00973c4
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:93ba38c8387dc8b7492c736f9c4bd5082aba87b679ecace18812eb2d88836e5e
+icr.io/cpopen/ibm-spectrum-scale-operator@sha256:e3fa797d4cc30a35050c78203fc38ed73637c1b0a61cbd4c18c29c69ba5fa649
+cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:54871bd8d09fd62d62dee7ffcae655297a0d73641849e962a4f5adac618e5b5e
+cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:3ed9321e4f3da7bbf75f99e8b4fd7b57139f793509b47a33cfeb51c66f20518f
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:ac0a1702d79c12b49e6cbcdabbc293d1cfe7c4dce60087f92d12e1c4d827f1cc
 cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-coredns@sha256:88cbfe40fd302a6467cb7e852b298f6c8d8659782ab313706d491d3ddf172a6e
 cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:65a14666cc3dc2ad7516b715f175ddfc18a6f2b5b6c1a3966560b03d6fd02f99
 cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:3692748b236758ada23f80a67fba5fbbf165acc995ce2da523de51a59a300675
 cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-logs@sha256:22c973b4ac5f6ff00a2cadc474c695513ad8246614ab0d145ae5612a6fd769f4
 cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:7ebe93f44ad6d08a6db9919b775819d2fd2780f3f426ed745736b9247da03ce9
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:5eeb3546a49fce400eb855be65ba00b2ae1eacc231c98e617e7185f080fc7b9a
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:3ec814f4260df9ac627a36e5682d7c73502b27b73854ec2edd3807f26b5b0d4f
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:de8f2f45b5cf33a018e8ffdda25d53f752d0365278587565306eb194696368e5
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:7a9e836c4385ff50c0bae957e1936d2a1a350ffc465bc278371f89f22d9e76b5
 cp.icr.io/cp/spectrum/scale/postgres@sha256:bbd7346fab25b7e0b25f214829d6ebfb78ef0465059492e46dee740ce8fcd844
 icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:fd1c27c6cf5d34782c5fe718486fab38ba9c8227b4d81961b5e39b692fbd6aa7
 # IBM Container Storage Interface (CSI) images

--- a/generated/scale/install.yaml
+++ b/generated/scale/install.yaml
@@ -8453,7 +8453,6 @@ metadata:
 ---
 apiVersion: v1
 imagePullSecrets:
-- name: ibm-spectrum-scale-registrykey
 - name: ibm-entitlement-key
 kind: ServiceAccount
 metadata:
@@ -8465,7 +8464,6 @@ metadata:
 ---
 apiVersion: v1
 imagePullSecrets:
-- name: ibm-spectrum-scale-registrykey
 - name: ibm-entitlement-key
 kind: ServiceAccount
 metadata:
@@ -8486,7 +8484,6 @@ metadata:
 ---
 apiVersion: v1
 imagePullSecrets:
-- name: ibm-spectrum-scale-registrykey
 - name: ibm-entitlement-key
 kind: ServiceAccount
 metadata:
@@ -8499,7 +8496,6 @@ metadata:
 apiVersion: v1
 automountServiceAccountToken: false
 imagePullSecrets:
-- name: ibm-spectrum-scale-registrykey
 - name: ibm-entitlement-key
 kind: ServiceAccount
 metadata:
@@ -8512,7 +8508,6 @@ metadata:
 apiVersion: v1
 automountServiceAccountToken: false
 imagePullSecrets:
-- name: ibm-spectrum-scale-registrykey
 - name: ibm-entitlement-key
 kind: ServiceAccount
 metadata:
@@ -8525,7 +8520,6 @@ metadata:
 apiVersion: v1
 automountServiceAccountToken: false
 imagePullSecrets:
-- name: ibm-spectrum-scale-registrykey
 - name: ibm-entitlement-key
 kind: ServiceAccount
 metadata:
@@ -8537,7 +8531,6 @@ metadata:
 ---
 apiVersion: v1
 imagePullSecrets:
-- name: ibm-spectrum-scale-registrykey
 - name: ibm-entitlement-key
 kind: ServiceAccount
 metadata:
@@ -10003,21 +9996,21 @@ data:
     apiVersion: scale.spectrum.ibm.com/v1alpha1
     kind: ClusterManagerConfig
     images:
-      coreECE: cp.icr.io/cp/spectrum/scale/erasure-code/ibm-spectrum-scale-daemon@sha256:4e999404fa87c8ae4084fe3f289017264abeda5b37fcca3df9b4c56b634f8d9e
-      coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:2e32514cec7dbc2f69606afebfaba423faff6ac02202eade9b60046bd00973c4
-      coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:3a5ae3d3d6d04c21d529cb8e725fae705fdba4ac4a2ca33e5c66a39c6cefa0a1
-      coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:93ba38c8387dc8b7492c736f9c4bd5082aba87b679ecace18812eb2d88836e5e
+      coreECE: cp.icr.io/cp/spectrum/scale/erasure-code/ibm-spectrum-scale-daemon@sha256:dd7d1b3b4e691008c007981df55896d4f2a79f3e189e83de463f81e855efd4e3
+      coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:3ed9321e4f3da7bbf75f99e8b4fd7b57139f793509b47a33cfeb51c66f20518f
+      coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:54871bd8d09fd62d62dee7ffcae655297a0d73641849e962a4f5adac618e5b5e
+      coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:ac0a1702d79c12b49e6cbcdabbc293d1cfe7c4dce60087f92d12e1c4d827f1cc
       gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:3692748b236758ada23f80a67fba5fbbf165acc995ce2da523de51a59a300675
       postgres: cp.icr.io/cp/spectrum/scale/postgres@sha256:bbd7346fab25b7e0b25f214829d6ebfb78ef0465059492e46dee740ce8fcd844
       logs: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-logs@sha256:22c973b4ac5f6ff00a2cadc474c695513ad8246614ab0d145ae5612a6fd769f4
-      pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:5eeb3546a49fce400eb855be65ba00b2ae1eacc231c98e617e7185f080fc7b9a
+      pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:de8f2f45b5cf33a018e8ffdda25d53f752d0365278587565306eb194696368e5
       sysmon: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:7ebe93f44ad6d08a6db9919b775819d2fd2780f3f426ed745736b9247da03ce9
       grafanaBridge: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:65a14666cc3dc2ad7516b715f175ddfc18a6f2b5b6c1a3966560b03d6fd02f99
       coreDNS: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-coredns@sha256:88cbfe40fd302a6467cb7e852b298f6c8d8659782ab313706d491d3ddf172a6e
       mustGather: icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:fd1c27c6cf5d34782c5fe718486fab38ba9c8227b4d81961b5e39b692fbd6aa7
-      ganesha: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-ganesha@sha256:6aebc97479025285f790aea051d95af9d04e1769f40c604fa7f86cfdfe1bcfb5
+      ganesha: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-ganesha@sha256:99c4c981a6ca7366af247c16890a23903a659195aefa9bbe9302247602260ce7
       stunnel: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-stunnel@sha256:bd1f4607c8b02063dde8aff7caa9eee732ffdf2c5d535d0b5eff6c9616359cdd
-      pmsensors: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:3ec814f4260df9ac627a36e5682d7c73502b27b73854ec2edd3807f26b5b0d4f
+      pmsensors: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:7a9e836c4385ff50c0bae957e1936d2a1a350ffc465bc278371f89f22d9e76b5
 kind: ConfigMap
 metadata:
   labels:
@@ -10225,7 +10218,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
-        image: icr.io/cpopen/ibm-spectrum-scale-operator@sha256:b6fb2a894bd05ce05580466f2307d4c871dc49da14453c96f081ab3b13c76bc8
+        image: icr.io/cpopen/ibm-spectrum-scale-operator@sha256:e3fa797d4cc30a35050c78203fc38ed73637c1b0a61cbd4c18c29c69ba5fa649
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
---------------------------------------------------------

* IBM Spectrum Scale Operator v5.2.1.1.3
* IBM Spectrum Scale v5.2.1.1.efix8
* IBM Spectrum Scale Container Storage Interface 2.12.1