### PR TITLE
IBM Spectrum Scale Container Native v5.1.9.10 06/11/2025

### DIFF
--- a/config/base/apis/scale/v1beta1/crd/scale.spectrum.ibm.com_clusters.yaml
+++ b/config/base/apis/scale/v1beta1/crd/scale.spectrum.ibm.com_clusters.yaml
@@ -556,7 +556,7 @@ spec:
                 properties:
                   accept:
                     description: Read the license and specify "true" to accept or
-                      "false" to not accept. https://www.ibm.com/support/customer/csol/terms/?id=L-PKAR-64DKYG
+                      "false" to not accept. https://www.ibm.com/support/customer/csol/terms/?id=L-WZNR-9SDY97
                       BY DOWNLOADING, INSTALLING, COPYING, ACCESSING, CLICKING ON
                       AN "ACCEPT" BUTTON, OR OTHERWISE USING THE PROGRAM, LICENSEE
                       AGREES TO THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING

--- a/config/cluster/components/cluster/scale_v1beta1_cluster.yaml
+++ b/config/cluster/components/cluster/scale_v1beta1_cluster.yaml
@@ -8,7 +8,7 @@ spec:
   # User must accept the Spectrum Scale license to deploy a CNSA cluster.
   # By specifying "accept: true" below, user agrees to the terms and conditions set
   # forth by the IBM Spectrum Scale Container Native Data Access/Data Management license located
-  # at https://www.ibm.com/support/customer/csol/terms/?id=L-PKAR-64DKYG
+  # at https://www.ibm.com/support/customer/csol/terms/?id=L-WZNR-9SDY97
   #
   # Enter either data-access or data-management to the license.license field. Customers entitled to
   # the Data Management Edition can use either data-management or data-access. Customers entitled to

--- a/config/csi/kustomization.yaml
+++ b/config/csi/kustomization.yaml
@@ -2,5 +2,5 @@
 namespace: ibm-spectrum-scale-csi
 
 resources:
-- github.com/IBM/ibm-spectrum-scale-csi.git//operator/config/overlays/cnsa?ref=v2.10.7
+- github.com/IBM/ibm-spectrum-scale-csi.git//operator/config/overlays/cnsa?ref=v2.10.8
 - namespace.yaml

--- a/config/operator/base/versionLabel.yaml
+++ b/config/operator/base/versionLabel.yaml
@@ -3,7 +3,7 @@ kind: LabelTransformer
 metadata:
   name: versionLabeler
 labels:
-  app.kubernetes.io/version: v5.1.9.9
+  app.kubernetes.io/version: v5.1.9.10
 fieldSpecs:
   - kind: Namespace
     path: metadata/labels

--- a/config/operator/components/manager/deploy/versionLabel.yaml
+++ b/config/operator/components/manager/deploy/versionLabel.yaml
@@ -5,7 +5,7 @@ metadata:
 labels:
   # DO NOT USE THE MINUS/DASH CHARACTER (-) AS PART OF THE VERSION NUMBER.
   # i.e v5.1.9.1-1 is NOT VALID, USE v5.1.9.1.1 INSTEAD.
-  app.kubernetes.io/version: v5.1.9.9
+  app.kubernetes.io/version: v5.1.9.10
 fieldSpecs:
   - kind: Deployment
     path: metadata/labels

--- a/config/operator/overlays/manager/controller_manager_config.yaml
+++ b/config/operator/overlays/manager/controller_manager_config.yaml
@@ -7,18 +7,18 @@ metrics:
 webhook:
   port: 9443
 images:
-  coreECE: cp.icr.io/cp/spectrum/scale/erasure-code/ibm-spectrum-scale-daemon@sha256:adfa93a3cdce126d428162e1d95a700321e4d3071501e51491e0801bfeda2d4b
-  coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:bdbe7adc67f6e9e8327f444b614e592762022fab739b082dfc6490633e054293
-  coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:b9c2193d6717560b83fa896f281ad099a2188b52d0b98ab24eda937b738c7af2
-  coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:34c794eed0dbe40bb67093fd3b22c7a57a921443b535cf14dedcafa4d697848d
-  gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:9e95951febaab00040743806b558d31cd0f1ec22ac30601239487d41d89986c2
+  coreECE: cp.icr.io/cp/spectrum/scale/erasure-code/ibm-spectrum-scale-daemon@sha256:5b128c01873b1bc8e033b9506ef0bd6dd5f275aa23af74a6108025ae0df02d90
+  coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:00ffcf508c1212841eb9915c66e7fa723ca3a7b95f23c933efbad3f3a84ce273
+  coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:9eb90c13c04f0d0c202be53a3c471b8a90d322b36a4ba488029b0f01ed1752dc
+  coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:e4b7ecadb723f39217bfda439ae58fa537a913552cbfa0c71247e6c0224c6d62
+  gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:0f8d7f433a16c0d8254d5604387f80f830914c74fdff05ddd5a7485b559f96a4
   postgres: cp.icr.io/cp/spectrum/scale/postgres@sha256:b2f06ce12103bedbc0a49ae4ffff062d90824e0f45462de712f66952679f7670
-  logs: cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
-  pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:6b197dbed8f6340dc7f99737c46307e7eeb8a27fa560405e97906a40cfd7c899
-  sysmon: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:f7e99f4df331cf1f1f9a235ba6fbcf62cc42ff57b281cd874d33aa9be1112fdf
-  grafanaBridge: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:0d52ac2e543fe256a44b0fb8282b23353d094f7e8f4f2dcc236ba9e079679bcc
+  logs: cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
+  pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:cb76b64eaca21d562717ade6d04b92812ac4f8dca006c3b61db80bbc5412f3dd
+  sysmon: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:59a92d0ea321b917de5e9114d39f891d1659357c12b5317bb6282f0c9cd8b226
+  grafanaBridge: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:4627f333f4b5e6d692c9dd7a1868c00912abed27155dcfd0915184ba1257662e
   coreDNS: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-coredns@sha256:879f0dd5c00590698be68f53005a7e538c6c6cca523854368640435df794d950
-  mustGather: icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:7854a658721838f5fae58595a6fb07a4dc98aae3387a6b1d5cbf9f9ba35a2d09
-  ganesha: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-ganesha@sha256:40cc73a3e8c5051fc13df697b67c59e1e6a77943346cc854a918c9a4df828a2e
-  stunnel: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-stunnel@sha256:fadf8a33e431d24dd540d4eba3efa07e9d43521dc1d75515a73219684004fd53
-  pmsensors: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:2d13521373ca2cf4ec3a30f8adc73d0e2360f88c1e2c5debf78e4cc30b2df303
+  mustGather: icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:367d038014e9f772e310eb6baf36590d20e9347261fec2cba97636739828b81e
+  ganesha: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-ganesha@sha256:74aa930c6501225e21bc32b7703d76ce022e8ff67e700358a26e144078ccc351
+  stunnel: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-stunnel@sha256:4a20eed834a7e9665c26d0435e4217cdc7737ce957fe2a8b82d70fd0c0cc5225
+  pmsensors: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:5e6073fdedd133215936cf3b17c2508b09a01049b5c027a267af6349f43ae318

--- a/config/operator/overlays/manager/kustomization.yaml
+++ b/config/operator/overlays/manager/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
   name: manager-config
 
 images:
-- digest: sha256:704c8d4abc1b145cd99346eda0cfc3cf77c3824643f219e39dcb7ccd02b187dd
+- digest: sha256:7e4fd0ffb813d034ec9b553d002b78c60e3a8f2550681613ce9c954d6e43109f
   name: controller
   newName: icr.io/cpopen/ibm-spectrum-scale-operator
 

--- a/generated/scale/README.md
+++ b/generated/scale/README.md
@@ -7,9 +7,9 @@ The images that are listed in the following table are the container images that 
 
 | Pod | Container | Repository | Image |
 |-----|-----------|------------|---------------------|
-| ibm-spectrum-scale-controller-manager-XXXXXXXXX-XXXXX | manager | icr.io/cpopen | ibm-spectrum-scale-operator@sha256:704c8d4abc1b145cd99346eda0cfc3cf77c3824643f219e39dcb7ccd02b187dd |
-| ibm-spectrum-scale-csi-operator | operator | icr.io/cpopen  | ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853 |
-| must-gather-XXXXX | must-gather | icr.io/cpopen | ibm-spectrum-scale-must-gather@sha256:7854a658721838f5fae58595a6fb07a4dc98aae3387a6b1d5cbf9f9ba35a2d09 |
+| ibm-spectrum-scale-controller-manager-XXXXXXXXX-XXXXX | manager | icr.io/cpopen | ibm-spectrum-scale-operator@sha256:7e4fd0ffb813d034ec9b553d002b78c60e3a8f2550681613ce9c954d6e43109f |
+| ibm-spectrum-scale-csi-operator | operator | icr.io/cpopen  | ibm-spectrum-scale-csi-operator@sha256:142bbc39ef762240505a7cba38a7ae1564876c50f071abc125f8e6da0632ef77 |
+| must-gather-XXXXX | must-gather | icr.io/cpopen | ibm-spectrum-scale-must-gather@sha256:367d038014e9f772e310eb6baf36590d20e9347261fec2cba97636739828b81e |
 
 ## IBM Storage Scale images acquired from entitled IBM Container Repository
 
@@ -17,18 +17,18 @@ The images that are listed in the following table are the container images that 
 
 | Pod | Container | Repository | Image |
 |-----|-----------|------------|---------------------|
-| workerX/masterX* | mmbuildgpl | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-core-init@sha256:34c794eed0dbe40bb67093fd3b22c7a57a921443b535cf14dedcafa4d697848d |
-| workerX/masterX* | config | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-core-init@sha256:34c794eed0dbe40bb67093fd3b22c7a57a921443b535cf14dedcafa4d697848d |
-| workerX/masterX* | gpfs (Data Access Edition) | cp.icr.io/cp/spectrum/scale/data-access | ibm-spectrum-scale-daemon@sha256:b9c2193d6717560b83fa896f281ad099a2188b52d0b98ab24eda937b738c7af2 |
-| workerX/masterX* | gpfs (Data Management Edition) | cp.icr.io/cp/spectrum/scale/data-management | ibm-spectrum-scale-daemon@sha256:bdbe7adc67f6e9e8327f444b614e592762022fab739b082dfc6490633e054293 |
-| workerX/masterX* | logs | cp.icr.io/cp/spectrum/scale | ubi-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0  |
-| ibm-spectrum-scale-gui-X | liberty | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-gui@sha256:9e95951febaab00040743806b558d31cd0f1ec22ac30601239487d41d89986c2 |
-| ibm-spectrum-scale-gui-X | sysmon | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-monitor@sha256:f7e99f4df331cf1f1f9a235ba6fbcf62cc42ff57b281cd874d33aa9be1112fdf |
+| workerX/masterX* | mmbuildgpl | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-core-init@sha256:e4b7ecadb723f39217bfda439ae58fa537a913552cbfa0c71247e6c0224c6d62 |
+| workerX/masterX* | config | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-core-init@sha256:e4b7ecadb723f39217bfda439ae58fa537a913552cbfa0c71247e6c0224c6d62 |
+| workerX/masterX* | gpfs (Data Access Edition) | cp.icr.io/cp/spectrum/scale/data-access | ibm-spectrum-scale-daemon@sha256:9eb90c13c04f0d0c202be53a3c471b8a90d322b36a4ba488029b0f01ed1752dc |
+| workerX/masterX* | gpfs (Data Management Edition) | cp.icr.io/cp/spectrum/scale/data-management | ibm-spectrum-scale-daemon@sha256:00ffcf508c1212841eb9915c66e7fa723ca3a7b95f23c933efbad3f3a84ce273 |
+| workerX/masterX* | logs | cp.icr.io/cp/spectrum/scale | ubi-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869  |
+| ibm-spectrum-scale-gui-X | liberty | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-gui@sha256:0f8d7f433a16c0d8254d5604387f80f830914c74fdff05ddd5a7485b559f96a4 |
+| ibm-spectrum-scale-gui-X | sysmon | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-monitor@sha256:59a92d0ea321b917de5e9114d39f891d1659357c12b5317bb6282f0c9cd8b226 |
 | ibm-spectrum-scale-gui-X | postgres | cp.icr.io/cp/spectrum/scale | postgres@sha256:b2f06ce12103bedbc0a49ae4ffff062d90824e0f45462de712f66952679f7670 |
-| ibm-spectrum-scale-gui-X | logs | cp.icr.io/cp/spectrum/scale | ubi-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0 |
-| ibm-spectrum-scale-pmcollector-X | pmcollector | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-pmcollector@sha256:6b197dbed8f6340dc7f99737c46307e7eeb8a27fa560405e97906a40cfd7c899 |
-| ibm-spectrum-scale-pmcollector-X | sysmon | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-monitor@sha256:f7e99f4df331cf1f1f9a235ba6fbcf62cc42ff57b281cd874d33aa9be1112fdf |
-| ibm-spectrum-scale-grafana-bridge-X | grafanabridge | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-grafana-bridge@sha256:0d52ac2e543fe256a44b0fb8282b23353d094f7e8f4f2dcc236ba9e079679bcc |
+| ibm-spectrum-scale-gui-X | logs | cp.icr.io/cp/spectrum/scale | ubi-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869 |
+| ibm-spectrum-scale-pmcollector-X | pmcollector | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-pmcollector@sha256:cb76b64eaca21d562717ade6d04b92812ac4f8dca006c3b61db80bbc5412f3dd |
+| ibm-spectrum-scale-pmcollector-X | sysmon | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-monitor@sha256:59a92d0ea321b917de5e9114d39f891d1659357c12b5317bb6282f0c9cd8b226 |
+| ibm-spectrum-scale-grafana-bridge-X | grafanabridge | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-grafana-bridge@sha256:4627f333f4b5e6d692c9dd7a1868c00912abed27155dcfd0915184ba1257662e |
 | coredns-XXXXX | coredns | cp.icr.io/cp/spectrum/scale | ibm-spectrum-scale-coredns@sha256:879f0dd5c00590698be68f53005a7e538c6c6cca523854368640435df794d950 |
 | ibm-spectrum-scale-csi-snapshotter | csi-snapshotter | cp.icr.io/cp/spectrum/scale/csi | csi-snapshotter@sha256:becc53e25b96573f61f7469923a92fb3e9d3a3781732159954ce0d9da07233a2  |
 | ibm-spectrum-scale-csi-attacher | ibm-spectrum-scale-csi-attacher | cp.icr.io/cp/spectrum/scale/csi | csi-attacher@sha256:4eb73137b66381b7b5dfd4d21d460f4b4095347ab6ed4626e0199c29d8d021af |
@@ -36,7 +36,7 @@ The images that are listed in the following table are the container images that 
 | ibm-spectrum-scale-csi-driver-XXXXX | liveness-probe | cp.icr.io/cp/spectrum/scale/csi | livenessprobe@sha256:4dc0b87ccd69f9865b89234d8555d3a614ab0a16ed94a3016ffd27f8106132ce |
 | ibm-spectrum-scale-csi-driver-XXXXX | driver-registrar | cp.icr.io/cp/spectrum/scale/csi | csi-node-driver-registrar@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1 |
 | ibm-spectrum-scale-csi-resizer-X | ibm-spectrum-scale-csi-resizer | cp.icr.io/cp/spectrum/scale/csi | csi-resizer@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0 |
-| ibm-spectrum-scale-csi-driver-XXXXX | ibm-spectrum-scale-csi | cp.icr.io/cp/spectrum/scale/csi | ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023 |
+| ibm-spectrum-scale-csi-driver-XXXXX | ibm-spectrum-scale-csi | cp.icr.io/cp/spectrum/scale/csi | ibm-spectrum-scale-csi-driver@sha256:9294e154a26e9f4f0e725b282a1092678b21bb7043709b0fd2fe9131e10786ce |
 
 *Pod names that contain the mmbuildgpl, config, and gpfs containers may vary. The pod name is based on the shortname of the node that it was scheduled to.
 
@@ -48,26 +48,26 @@ When setting up your environment to be air-gapped, use `skopeo` to copy the foll
 
 ```bash
 # IBM Storage Scale container native images
-icr.io/cpopen/ibm-spectrum-scale-operator@sha256:704c8d4abc1b145cd99346eda0cfc3cf77c3824643f219e39dcb7ccd02b187dd
-cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:b9c2193d6717560b83fa896f281ad099a2188b52d0b98ab24eda937b738c7af2
-cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:bdbe7adc67f6e9e8327f444b614e592762022fab739b082dfc6490633e054293
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:34c794eed0dbe40bb67093fd3b22c7a57a921443b535cf14dedcafa4d697848d
+icr.io/cpopen/ibm-spectrum-scale-operator@sha256:7e4fd0ffb813d034ec9b553d002b78c60e3a8f2550681613ce9c954d6e43109f
+cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:9eb90c13c04f0d0c202be53a3c471b8a90d322b36a4ba488029b0f01ed1752dc
+cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:00ffcf508c1212841eb9915c66e7fa723ca3a7b95f23c933efbad3f3a84ce273
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:e4b7ecadb723f39217bfda439ae58fa537a913552cbfa0c71247e6c0224c6d62
 cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-coredns@sha256:879f0dd5c00590698be68f53005a7e538c6c6cca523854368640435df794d950
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:0d52ac2e543fe256a44b0fb8282b23353d094f7e8f4f2dcc236ba9e079679bcc
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:9e95951febaab00040743806b558d31cd0f1ec22ac30601239487d41d89986c2
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:f7e99f4df331cf1f1f9a235ba6fbcf62cc42ff57b281cd874d33aa9be1112fdf
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:6b197dbed8f6340dc7f99737c46307e7eeb8a27fa560405e97906a40cfd7c899
-cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:2d13521373ca2cf4ec3a30f8adc73d0e2360f88c1e2c5debf78e4cc30b2df303
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:4627f333f4b5e6d692c9dd7a1868c00912abed27155dcfd0915184ba1257662e
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:0f8d7f433a16c0d8254d5604387f80f830914c74fdff05ddd5a7485b559f96a4
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:59a92d0ea321b917de5e9114d39f891d1659357c12b5317bb6282f0c9cd8b226
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:cb76b64eaca21d562717ade6d04b92812ac4f8dca006c3b61db80bbc5412f3dd
+cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:5e6073fdedd133215936cf3b17c2508b09a01049b5c027a267af6349f43ae318
 cp.icr.io/cp/spectrum/scale/postgres@sha256:b2f06ce12103bedbc0a49ae4ffff062d90824e0f45462de712f66952679f7670
-cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
-icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:7854a658721838f5fae58595a6fb07a4dc98aae3387a6b1d5cbf9f9ba35a2d09
+cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
+icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:367d038014e9f772e310eb6baf36590d20e9347261fec2cba97636739828b81e
 # IBM Container Storage Interface (CSI) images
-icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
+icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:142bbc39ef762240505a7cba38a7ae1564876c50f071abc125f8e6da0632ef77
 cp.icr.io/cp/spectrum/scale/csi/csi-attacher@sha256:4eb73137b66381b7b5dfd4d21d460f4b4095347ab6ed4626e0199c29d8d021af
 cp.icr.io/cp/spectrum/scale/csi/csi-node-driver-registrar@sha256:f6717ce72a2615c7fbc746b4068f788e78579c54c43b8716e5ce650d97af2df1
 cp.icr.io/cp/spectrum/scale/csi/csi-provisioner@sha256:d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f
 cp.icr.io/cp/spectrum/scale/csi/csi-resizer@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0
 cp.icr.io/cp/spectrum/scale/csi/csi-snapshotter@sha256:becc53e25b96573f61f7469923a92fb3e9d3a3781732159954ce0d9da07233a2
-cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
+cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:9294e154a26e9f4f0e725b282a1092678b21bb7043709b0fd2fe9131e10786ce
 cp.icr.io/cp/spectrum/scale/csi/livenessprobe@sha256:4dc0b87ccd69f9865b89234d8555d3a614ab0a16ed94a3016ffd27f8106132ce
 ```

--- a/generated/scale/install-excluding-operator.yaml
+++ b/generated/scale/install-excluding-operator.yaml
@@ -43,7 +43,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: ibm-spectrum-scale
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: v5.1.9.9
+    app.kubernetes.io/version: v5.1.9.10
     control-plane: controller-manager
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/enforce: restricted
@@ -1654,7 +1654,7 @@ spec:
                 properties:
                   accept:
                     description: Read the license and specify "true" to accept or
-                      "false" to not accept. https://www.ibm.com/support/customer/csol/terms/?id=L-PKAR-64DKYG
+                      "false" to not accept. https://www.ibm.com/support/customer/csol/terms/?id=L-WZNR-9SDY97
                       BY DOWNLOADING, INSTALLING, COPYING, ACCESSING, CLICKING ON
                       AN "ACCEPT" BUTTON, OR OTHERWISE USING THE PROGRAM, LICENSEE
                       AGREES TO THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING
@@ -9536,7 +9536,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    productVersion: 2.10.7
+    productVersion: 2.10.8
   labels:
     app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
     app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
@@ -9555,7 +9555,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.7
+        productVersion: 2.10.8
       labels:
         app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
         app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
@@ -9594,14 +9594,14 @@ spec:
         - name: CSI_RESIZER_IMAGE
           value: cp.icr.io/cp/spectrum/scale/csi/csi-resizer@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0
         - name: CSI_DRIVER_IMAGE
-          value: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
+          value: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:9294e154a26e9f4f0e725b282a1092678b21bb7043709b0fd2fe9131e10786ce
         - name: METRICS_BIND_ADDRESS
           value: "8383"
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
+        image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:142bbc39ef762240505a7cba38a7ae1564876c50f071abc125f8e6da0632ef77
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/generated/scale/install.yaml
+++ b/generated/scale/install.yaml
@@ -43,7 +43,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: ibm-spectrum-scale
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: v5.1.9.9
+    app.kubernetes.io/version: v5.1.9.10
     control-plane: controller-manager
     pod-security.kubernetes.io/audit: restricted
     pod-security.kubernetes.io/enforce: restricted
@@ -1654,7 +1654,7 @@ spec:
                 properties:
                   accept:
                     description: Read the license and specify "true" to accept or
-                      "false" to not accept. https://www.ibm.com/support/customer/csol/terms/?id=L-PKAR-64DKYG
+                      "false" to not accept. https://www.ibm.com/support/customer/csol/terms/?id=L-WZNR-9SDY97
                       BY DOWNLOADING, INSTALLING, COPYING, ACCESSING, CLICKING ON
                       AN "ACCEPT" BUTTON, OR OTHERWISE USING THE PROGRAM, LICENSEE
                       AGREES TO THE TERMS OF THIS AGREEMENT. IF YOU ARE ACCEPTING
@@ -9525,21 +9525,21 @@ data:
     webhook:
       port: 9443
     images:
-      coreECE: cp.icr.io/cp/spectrum/scale/erasure-code/ibm-spectrum-scale-daemon@sha256:adfa93a3cdce126d428162e1d95a700321e4d3071501e51491e0801bfeda2d4b
-      coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:bdbe7adc67f6e9e8327f444b614e592762022fab739b082dfc6490633e054293
-      coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:b9c2193d6717560b83fa896f281ad099a2188b52d0b98ab24eda937b738c7af2
-      coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:34c794eed0dbe40bb67093fd3b22c7a57a921443b535cf14dedcafa4d697848d
-      gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:9e95951febaab00040743806b558d31cd0f1ec22ac30601239487d41d89986c2
+      coreECE: cp.icr.io/cp/spectrum/scale/erasure-code/ibm-spectrum-scale-daemon@sha256:5b128c01873b1bc8e033b9506ef0bd6dd5f275aa23af74a6108025ae0df02d90
+      coreDME: cp.icr.io/cp/spectrum/scale/data-management/ibm-spectrum-scale-daemon@sha256:00ffcf508c1212841eb9915c66e7fa723ca3a7b95f23c933efbad3f3a84ce273
+      coreDAE: cp.icr.io/cp/spectrum/scale/data-access/ibm-spectrum-scale-daemon@sha256:9eb90c13c04f0d0c202be53a3c471b8a90d322b36a4ba488029b0f01ed1752dc
+      coreInit: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-core-init@sha256:e4b7ecadb723f39217bfda439ae58fa537a913552cbfa0c71247e6c0224c6d62
+      gui: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-gui@sha256:0f8d7f433a16c0d8254d5604387f80f830914c74fdff05ddd5a7485b559f96a4
       postgres: cp.icr.io/cp/spectrum/scale/postgres@sha256:b2f06ce12103bedbc0a49ae4ffff062d90824e0f45462de712f66952679f7670
-      logs: cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:14f14e03d68f7fd5f2b18a13478b6b127c341b346c86b6e0b886ed2b7573b8e0
-      pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:6b197dbed8f6340dc7f99737c46307e7eeb8a27fa560405e97906a40cfd7c899
-      sysmon: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:f7e99f4df331cf1f1f9a235ba6fbcf62cc42ff57b281cd874d33aa9be1112fdf
-      grafanaBridge: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:0d52ac2e543fe256a44b0fb8282b23353d094f7e8f4f2dcc236ba9e079679bcc
+      logs: cp.icr.io/cp/spectrum/scale/ubi-minimal@sha256:ac61c96b93894b9169221e87718733354dd3765dd4a62b275893c7ff0d876869
+      pmcollector: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmcollector@sha256:cb76b64eaca21d562717ade6d04b92812ac4f8dca006c3b61db80bbc5412f3dd
+      sysmon: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-monitor@sha256:59a92d0ea321b917de5e9114d39f891d1659357c12b5317bb6282f0c9cd8b226
+      grafanaBridge: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-grafana-bridge@sha256:4627f333f4b5e6d692c9dd7a1868c00912abed27155dcfd0915184ba1257662e
       coreDNS: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-coredns@sha256:879f0dd5c00590698be68f53005a7e538c6c6cca523854368640435df794d950
-      mustGather: icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:7854a658721838f5fae58595a6fb07a4dc98aae3387a6b1d5cbf9f9ba35a2d09
-      ganesha: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-ganesha@sha256:40cc73a3e8c5051fc13df697b67c59e1e6a77943346cc854a918c9a4df828a2e
-      stunnel: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-stunnel@sha256:fadf8a33e431d24dd540d4eba3efa07e9d43521dc1d75515a73219684004fd53
-      pmsensors: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:2d13521373ca2cf4ec3a30f8adc73d0e2360f88c1e2c5debf78e4cc30b2df303
+      mustGather: icr.io/cpopen/ibm-spectrum-scale-must-gather@sha256:367d038014e9f772e310eb6baf36590d20e9347261fec2cba97636739828b81e
+      ganesha: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-ganesha@sha256:74aa930c6501225e21bc32b7703d76ce022e8ff67e700358a26e144078ccc351
+      stunnel: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-stunnel@sha256:4a20eed834a7e9665c26d0435e4217cdc7737ce957fe2a8b82d70fd0c0cc5225
+      pmsensors: cp.icr.io/cp/spectrum/scale/ibm-spectrum-scale-pmsensors@sha256:5e6073fdedd133215936cf3b17c2508b09a01049b5c027a267af6349f43ae318
 kind: ConfigMap
 metadata:
   labels:
@@ -9571,7 +9571,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    productVersion: 2.10.7
+    productVersion: 2.10.8
   labels:
     app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
     app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
@@ -9590,7 +9590,7 @@ spec:
       annotations:
         productID: ibm-spectrum-scale-csi-operator
         productName: IBM Spectrum Scale CSI Operator
-        productVersion: 2.10.7
+        productVersion: 2.10.8
       labels:
         app.kubernetes.io/instance: ibm-spectrum-scale-csi-operator
         app.kubernetes.io/managed-by: ibm-spectrum-scale-csi-operator
@@ -9629,14 +9629,14 @@ spec:
         - name: CSI_RESIZER_IMAGE
           value: cp.icr.io/cp/spectrum/scale/csi/csi-resizer@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0
         - name: CSI_DRIVER_IMAGE
-          value: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:51af18efe71c1078d7257d199c2566ab7b71367bc302cfdadecbaad8dfec8023
+          value: cp.icr.io/cp/spectrum/scale/csi/ibm-spectrum-scale-csi-driver@sha256:9294e154a26e9f4f0e725b282a1092678b21bb7043709b0fd2fe9131e10786ce
         - name: METRICS_BIND_ADDRESS
           value: "8383"
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:fd0bd1a72471d51af65a8eb968ec36706f3761aff678454d42c2bdf1ac04f853
+        image: icr.io/cpopen/ibm-spectrum-scale-csi-operator@sha256:142bbc39ef762240505a7cba38a7ae1564876c50f071abc125f8e6da0632ef77
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -9689,7 +9689,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: ibm-spectrum-scale
     app.kubernetes.io/name: operator
-    app.kubernetes.io/version: v5.1.9.9
+    app.kubernetes.io/version: v5.1.9.10
     control-plane: controller-manager
   name: ibm-spectrum-scale-controller-manager
   namespace: ibm-spectrum-scale-operator
@@ -9705,7 +9705,7 @@ spec:
       labels:
         app.kubernetes.io/instance: ibm-spectrum-scale
         app.kubernetes.io/name: operator
-        app.kubernetes.io/version: v5.1.9.9
+        app.kubernetes.io/version: v5.1.9.10
         control-plane: controller-manager
     spec:
       affinity:
@@ -9736,7 +9736,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
-        image: icr.io/cpopen/ibm-spectrum-scale-operator@sha256:704c8d4abc1b145cd99346eda0cfc3cf77c3824643f219e39dcb7ccd02b187dd
+        image: icr.io/cpopen/ibm-spectrum-scale-operator@sha256:7e4fd0ffb813d034ec9b553d002b78c60e3a8f2550681613ce9c954d6e43109f
         livenessProbe:
           httpGet:
             path: /healthz

--- a/generated/scale/v1beta1/cluster/cluster.yaml
+++ b/generated/scale/v1beta1/cluster/cluster.yaml
@@ -53,7 +53,7 @@ spec:
   # User must accept the Spectrum Scale license to deploy a CNSA cluster.
   # By specifying "accept: true" below, user agrees to the terms and conditions set
   # forth by the IBM Spectrum Scale Container Native Data Access/Data Management license located
-  # at https://www.ibm.com/support/customer/csol/terms/?id=L-PKAR-64DKYG
+  # at https://www.ibm.com/support/customer/csol/terms/?id=L-WZNR-9SDY97
   #
   # Enter either data-access or data-management to the license.license field. Customers entitled to
   # the Data Management Edition can use either data-management or data-access. Customers entitled to


### PR DESCRIPTION
--------------------------------------------------------

* IBM Spectrum Scale Operator v5.1.9.10
* IBM Spectrum Scale v5.1.9.10
* IBM Spectrum Scale Container Storage Interface 2.10.8